### PR TITLE
1.2.1 Release

### DIFF
--- a/moss-bungeecord/build.gradle
+++ b/moss-bungeecord/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 def id = 'moss-bungeecord'
 def domain = 'games.negative.moss'
-def apiVersion = '1.2.0-SNAPSHOT'
+def apiVersion = '1.2.1'
 
 repositories {
     mavenCentral()

--- a/moss-paper/build.gradle
+++ b/moss-paper/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 def id = 'moss-paper'
 def domain = 'games.negative.moss'
-def apiVersion = '1.2.0-SNAPSHOT'
+def apiVersion = '1.2.1'
 
 repositories {
     mavenCentral()

--- a/moss-velocity/build.gradle
+++ b/moss-velocity/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 def id = 'moss-velocity'
 def domain = 'games.negative.moss'
-def apiVersion = '1.2.0-SNAPSHOT'
+def apiVersion = '1.2.1'
 
 repositories {
     mavenCentral()

--- a/moss/build.gradle
+++ b/moss/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 def id = 'moss-common'
 def domain = 'games.negative.moss'
-def apiVersion = '1.2.0-SNAPSHOT'
+def apiVersion = '1.2.1'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This pull request updates the plugin API version across all modules from `1.2.0-SNAPSHOT` to `1.2.1`. This ensures consistency and prepares the plugins for a new release.

Version updates for plugin modules:

* Updated `apiVersion` to `1.2.1` in `moss/build.gradle` for the common module.
* Updated `apiVersion` to `1.2.1` in `moss-bungeecord/build.gradle` for the BungeeCord plugin.
* Updated `apiVersion` to `1.2.1` in `moss-paper/build.gradle` for the Paper plugin.
* Updated `apiVersion` to `1.2.1` in `moss-velocity/build.gradle` for the Velocity plugin.Updated the apiVersion from 1.2.0-SNAPSHOT to 1.2.1 in build.gradle for moss, moss-bungeecord, moss-paper, and moss-velocity modules to reflect the new release version.