### PR TITLE
Publish to Maven Central with signing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Negative Games Nexus (Gradle)
+name: Deploy to Maven Central (Gradle)
 
 on:
   push:
@@ -23,38 +23,37 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Configure Gradle / Nexus credentials
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+
+      - name: Configure Gradle properties
         run: |
           mkdir -p ~/.gradle
-          cat << 'EOF' > ~/.gradle/gradle.properties
-          nexusUsername=${{ secrets.NEXUS_USERNAME }}
-          nexusPassword=${{ secrets.NEXUS_PASSWORD }}
-          nexusSnapshotsUrl=https://repo.negative.games/repository/maven-snapshots
-          nexusReleasesUrl=https://repo.negative.games/repository/maven-releases
+          cat << EOF > ~/.gradle/gradle.properties
+          mavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          mavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          signing.gnupg.keyName=${{ secrets.GPG_KEY_ID }}
+          signing.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }}
           EOF
 
-      # Modify version for release branch (remove -SNAPSHOT)
       - name: Modify version for release
         if: github.ref == 'refs/heads/release'
         run: |
           find . -name "build.gradle" -type f -exec sed -i "s/\(def apiVersion = '[^']*\)-SNAPSHOT'/\1'/" {} +
 
-      # Modify version for snapshot branch (add -SNAPSHOT if not present)
       - name: Modify version for snapshot
         if: github.ref == 'refs/heads/snapshot'
         run: |
           find . -name "build.gradle" -type f -exec sed -i "/-SNAPSHOT'/! s/\(def apiVersion = '[^']*\)'/\1-SNAPSHOT'/" {} +
 
-      # Make gradlew executable
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # Deploy to RELEASES on release branch
       - name: Build and deploy release
         if: github.ref == 'refs/heads/release'
         run: ./gradlew clean publish -PisRelease=true
 
-      # Deploy to SNAPSHOTS on snapshot branch
       - name: Build and deploy snapshot
         if: github.ref == 'refs/heads/snapshot'
         run: ./gradlew clean publish -PisRelease=false

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'signing'
 }
 
 repositories {
@@ -14,25 +15,30 @@ dependencies {
 }
 
 subprojects {
-    // Only configure projects that use maven-publish
     plugins.withId('maven-publish') {
         publishing {
             repositories {
                 maven {
-                    name = "nexus"
+                    name = "mavenCentral"
 
-                    def snapshotsUrl = findProperty("nexusSnapshotsUrl") ?: "https://repo.negative.games/repository/maven-snapshots"
-                    def releasesUrl  = findProperty("nexusReleasesUrl")  ?: "https://repo.negative.games/repository/maven-releases"
-
-                    // Controlled via -PisRelease=true|false (or default to snapshots)
                     def isRelease = (findProperty("isRelease") == "true")
-                    url = uri(isRelease ? releasesUrl : snapshotsUrl)
+                    url = uri(isRelease
+                            ? "https://central.sonatype.com/api/v1/publisher/deployments/download/"
+                            : "https://central.sonatype.com/repository/maven-snapshots/"
+                    )
 
                     credentials {
-                        username = findProperty("nexusUsername")
-                        password = findProperty("nexusPassword")
+                        username = findProperty("mavenCentralUsername")
+                        password = findProperty("mavenCentralPassword")
                     }
                 }
+            }
+        }
+
+        plugins.withId('signing') {
+            signing {
+                useGpgCmd()
+                sign publishing.publications
             }
         }
     }

--- a/moss-bungeecord/build.gradle
+++ b/moss-bungeecord/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
 }
 
@@ -61,21 +62,33 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
+tasks.register('javadocJar', Jar) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    dependsOn javadoc
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
+            artifact(tasks.sourcesJar)
+            artifact(tasks.javadocJar)
 
-            // Explicit coordinates (optional, defaults to project.group/name/version)
             groupId = "${domain}"
             artifactId = "${id}"
             version = "${apiVersion}"
 
             pom {
                 name = "${id}"
-                description = project.description
+                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -91,7 +104,18 @@ publishing {
                         name = 'Eric'
                     }
                 }
+
+                scm {
+                    url = 'https://github.com/negative-games/moss'
+                    connection = 'scm:git:git://github.com/negative-games/moss.git'
+                    developerConnection = 'scm:git:ssh://github.com/negative-games/moss.git'
+                }
             }
         }
     }
+}
+
+signing {
+    useGpgCmd()
+    sign publishing.publications.mavenJava
 }

--- a/moss-paper/build.gradle
+++ b/moss-paper/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
 }
-
 def id = 'moss-paper'
 def domain = 'games.negative.moss'
 def apiVersion = '1.2.1'
@@ -58,21 +58,33 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
+tasks.register('javadocJar', Jar) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    dependsOn javadoc
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
+            artifact(tasks.sourcesJar)
+            artifact(tasks.javadocJar)
 
-            // Explicit coordinates (optional, defaults to project.group/name/version)
             groupId = "${domain}"
             artifactId = "${id}"
             version = "${apiVersion}"
 
             pom {
                 name = "${id}"
-                description = project.description
+                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -88,7 +100,18 @@ publishing {
                         name = 'Eric'
                     }
                 }
+
+                scm {
+                    url = 'https://github.com/negative-games/moss'
+                    connection = 'scm:git:git://github.com/negative-games/moss.git'
+                    developerConnection = 'scm:git:ssh://github.com/negative-games/moss.git'
+                }
             }
         }
     }
+}
+
+signing {
+    useGpgCmd()
+    sign publishing.publications.mavenJava
 }

--- a/moss-velocity/build.gradle
+++ b/moss-velocity/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
 }
 
@@ -58,21 +59,33 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
+tasks.register('javadocJar', Jar) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    dependsOn javadoc
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
+            artifact(tasks.sourcesJar)
+            artifact(tasks.javadocJar)
 
-            // Explicit coordinates (optional, defaults to project.group/name/version)
             groupId = "${domain}"
             artifactId = "${id}"
             version = "${apiVersion}"
 
             pom {
                 name = "${id}"
-                description = project.description
+                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -88,7 +101,18 @@ publishing {
                         name = 'Eric'
                     }
                 }
+
+                scm {
+                    url = 'https://github.com/negative-games/moss'
+                    connection = 'scm:git:git://github.com/negative-games/moss.git'
+                    developerConnection = 'scm:git:ssh://github.com/negative-games/moss.git'
+                }
             }
         }
     }
+}
+
+signing {
+    useGpgCmd()
+    sign publishing.publications.mavenJava
 }

--- a/moss/build.gradle
+++ b/moss/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'maven-publish'
+    id 'signing'
 }
 
 def id = 'moss-common'
@@ -38,19 +39,30 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
+tasks.register('sourcesJar', Jar) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
+tasks.register('javadocJar', Jar) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+    dependsOn javadoc
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            from components.java
+            artifact(tasks.sourcesJar)
+            artifact(tasks.javadocJar)
 
-            // Explicit coordinates (optional, defaults to project.group/name/version)
             groupId = "${domain}"
             artifactId = "${id}"
             version = "${apiVersion}"
 
             pom {
                 name = "${id}"
-                description = project.description
+                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -66,7 +78,18 @@ publishing {
                         name = 'Eric'
                     }
                 }
+
+                scm {
+                    url = 'https://github.com/negative-games/moss'
+                    connection = 'scm:git:git://github.com/negative-games/moss.git'
+                    developerConnection = 'scm:git:ssh://github.com/negative-games/moss.git'
+                }
             }
         }
     }
+}
+
+signing {
+    useGpgCmd()
+    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
Switch CI and Gradle publishing from the private Nexus to Maven Central and add artifact signing. Updates include:

- CI: rename workflow, import GPG key, set Gradle properties to use MAVEN_CENTRAL_* and GPG secrets, and keep release/snapshot publish steps.
- Root build.gradle: add signing plugin, update repository URLs/credentials for Sonatype, and configure signing for publications.
- Subprojects (moss-*, moss): add signing plugin, register sources and javadoc JAR tasks, attach those artifacts to the mavenJava publication, enrich POM metadata (description and SCM), and enable signing of the publication.

These changes enable signed uploads to Maven Central (Sonatype) and provide sources/javadoc artifacts and proper POM metadata for consumers.