### PR TITLE
Update Deploy Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,14 +50,10 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      # List available publishing tasks for debugging
-      - name: List publishing tasks
-        run: ./gradlew tasks --group=publishing
-
       - name: Build and deploy release
         if: github.ref == 'refs/heads/release'
-        run: ./gradlew clean centralPortalUpload -PisRelease=true
+        run: ./gradlew clean :moss:publish :moss-paper:publish :moss-velocity:publish :moss-bungeecord:publish -PisRelease=true
 
       - name: Build and deploy snapshot
         if: github.ref == 'refs/heads/snapshot'
-        run: ./gradlew clean centralPortalUpload -PisRelease=false
+        run: ./gradlew clean :moss:publish :moss-paper:publish :moss-velocity:publish :moss-bungeecord:publish -PisRelease=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,10 +50,14 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
+      # List available publishing tasks for debugging
+      - name: List publishing tasks
+        run: ./gradlew tasks --group=publishing
+
       - name: Build and deploy release
         if: github.ref == 'refs/heads/release'
-        run: ./gradlew clean publishToSonatypeCentralPortal -PisRelease=true
+        run: ./gradlew clean centralPortalUpload -PisRelease=true
 
       - name: Build and deploy snapshot
         if: github.ref == 'refs/heads/snapshot'
-        run: ./gradlew clean publishToSonatypeCentralPortal -PisRelease=false
+        run: ./gradlew clean centralPortalUpload -PisRelease=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Build and deploy release
         if: github.ref == 'refs/heads/release'
-        run: ./gradlew clean publish -PisRelease=true
+        run: ./gradlew clean publishToSonatypeCentralPortal -PisRelease=true
 
       - name: Build and deploy snapshot
         if: github.ref == 'refs/heads/snapshot'
-        run: ./gradlew clean publish -PisRelease=false
+        run: ./gradlew clean publishToSonatypeCentralPortal -PisRelease=false

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'java'
-    id 'maven-publish'
-    id 'signing'
 }
 
 repositories {
@@ -12,34 +10,4 @@ dependencies {
     // Lombok
     compileOnly("org.projectlombok:lombok:1.18.32")
     annotationProcessor("org.projectlombok:lombok:1.18.32")
-}
-
-subprojects {
-    plugins.withId('maven-publish') {
-        publishing {
-            repositories {
-                maven {
-                    name = "mavenCentral"
-
-                    def isRelease = (findProperty("isRelease") == "true")
-                    url = uri(isRelease
-                            ? "https://central.sonatype.com/api/v1/publisher/deployments/download/"
-                            : "https://central.sonatype.com/repository/maven-snapshots/"
-                    )
-
-                    credentials {
-                        username = findProperty("mavenCentralUsername")
-                        password = findProperty("mavenCentralPassword")
-                    }
-                }
-            }
-        }
-
-        plugins.withId('signing') {
-            signing {
-                useGpgCmd()
-                sign publishing.publications
-            }
-        }
-    }
 }

--- a/moss-bungeecord/build.gradle
+++ b/moss-bungeecord/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
+    id 'net.thebugmc.gradle.sonatype-central-portal-publisher' version '1.2.4'
 }
 
 def id = 'moss-bungeecord'
@@ -62,25 +63,14 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-tasks.register('javadocJar', Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-    dependsOn javadoc
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
-            artifact(tasks.sourcesJar)
-            artifact(tasks.javadocJar)
+            artifact sourcesJar
+            artifact javadocJar
 
             groupId = "${domain}"
             artifactId = "${id}"
@@ -88,7 +78,7 @@ publishing {
 
             pom {
                 name = "${id}"
-                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
+                description = 'Moss BungeeCord module - A Spring-based Minecraft proxy framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -113,6 +103,12 @@ publishing {
             }
         }
     }
+}
+
+centralPortal {
+    username = findProperty("mavenCentralUsername")
+    password = findProperty("mavenCentralPassword")
+    publishingType = 'AUTOMATIC'
 }
 
 signing {

--- a/moss-paper/build.gradle
+++ b/moss-paper/build.gradle
@@ -3,7 +3,9 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
+    id 'net.thebugmc.gradle.sonatype-central-portal-publisher' version '1.2.4'
 }
+
 def id = 'moss-paper'
 def domain = 'games.negative.moss'
 def apiVersion = '1.2.1'
@@ -58,25 +60,14 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-tasks.register('javadocJar', Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-    dependsOn javadoc
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
-            artifact(tasks.sourcesJar)
-            artifact(tasks.javadocJar)
+            artifact sourcesJar
+            artifact javadocJar
 
             groupId = "${domain}"
             artifactId = "${id}"
@@ -84,7 +75,7 @@ publishing {
 
             pom {
                 name = "${id}"
-                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
+                description = 'Moss Paper module - A Spring-based Minecraft plugin framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {
@@ -109,6 +100,12 @@ publishing {
             }
         }
     }
+}
+
+centralPortal {
+    username = findProperty("mavenCentralUsername")
+    password = findProperty("mavenCentralPassword")
+    publishingType = 'AUTOMATIC'
 }
 
 signing {

--- a/moss-velocity/build.gradle
+++ b/moss-velocity/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.gradleup.shadow' version '9.2.2'
+    id 'net.thebugmc.gradle.sonatype-central-portal-publisher' version '1.2.4'
 }
 
 def id = 'moss-velocity'
@@ -59,25 +60,14 @@ tasks.shadowJar {
     archiveClassifier.set("")
 }
 
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-tasks.register('javadocJar', Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-    dependsOn javadoc
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
             artifact(tasks.shadowJar) {
                 builtBy tasks.shadowJar
             }
-            artifact(tasks.sourcesJar)
-            artifact(tasks.javadocJar)
+            artifact sourcesJar
+            artifact javadocJar
 
             groupId = "${domain}"
             artifactId = "${id}"
@@ -110,6 +100,12 @@ publishing {
             }
         }
     }
+}
+
+centralPortal {
+    username = findProperty("mavenCentralUsername")
+    password = findProperty("mavenCentralPassword")
+    publishingType = 'AUTOMATIC'
 }
 
 signing {

--- a/moss/build.gradle
+++ b/moss/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'signing'
+    id 'com.gradleup.shadow' version '9.2.2'
+    id 'net.thebugmc.gradle.sonatype-central-portal-publisher' version '1.2.4'
 }
 
 def id = 'moss-common'
@@ -39,17 +41,6 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
-tasks.register('sourcesJar', Jar) {
-    archiveClassifier.set('sources')
-    from sourceSets.main.allSource
-}
-
-tasks.register('javadocJar', Jar) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-    dependsOn javadoc
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -62,7 +53,7 @@ publishing {
 
             pom {
                 name = "${id}"
-                description = 'Moss Velocity module - A Spring-based Minecraft proxy framework'
+                description = 'Moss Core module - A Spring-based framework'
                 url = 'https://github.com/negative-games/moss'
 
                 licenses {


### PR DESCRIPTION
This pull request updates the build and publishing configuration for all Moss modules to streamline and automate publishing to Maven Central. The key changes include adding the Sonatype Central Portal Publisher plugin, simplifying the artifact publishing process, and updating project descriptions. Additionally, the GitHub Actions workflow for deployment is updated to explicitly publish all modules.

**Build and Publishing Automation:**

* Added the `net.thebugmc.gradle.sonatype-central-portal-publisher` plugin (version 1.2.4) to all module `build.gradle` files (`moss`, `moss-paper`, `moss-velocity`, `moss-bungeecord`) to enable automated publishing to Maven Central. [[1]](diffhunk://#diff-72cbe082f9ddb320919fd00247b5b1ee9d694751fca9601ffe9d4b73b7ac1eeeR5-R6) [[2]](diffhunk://#diff-b102daf76304a35b2fc0a53b39e3d2490f1f88373ed3c9dcbddb8f60c0a38baaR6-R8) [[3]](diffhunk://#diff-d03bb560ec65aea56e6a74f4e6f7ef32cd44a08d354190f26df645f5e95231dcR6) [[4]](diffhunk://#diff-851d1eadda3f82d084b249979193f09471481b3c0c8624095131aa45ef6d5b94R6)
* Introduced a `centralPortal` configuration block in each module to use credentials from project properties and set publishing type to `AUTOMATIC`. [[1]](diffhunk://#diff-72cbe082f9ddb320919fd00247b5b1ee9d694751fca9601ffe9d4b73b7ac1eeeL65-R56) [[2]](diffhunk://#diff-b102daf76304a35b2fc0a53b39e3d2490f1f88373ed3c9dcbddb8f60c0a38baaR105-R110) [[3]](diffhunk://#diff-d03bb560ec65aea56e6a74f4e6f7ef32cd44a08d354190f26df645f5e95231dcR105-R110) [[4]](diffhunk://#diff-851d1eadda3f82d084b249979193f09471481b3c0c8624095131aa45ef6d5b94R108-R113)

**Artifact Publishing Simplification:**

* Replaced manual `sourcesJar` and `javadocJar` task registration with references to `sourcesJar` and `javadocJar` artifacts directly in the `publishing` block, simplifying the build scripts. [[1]](diffhunk://#diff-72cbe082f9ddb320919fd00247b5b1ee9d694751fca9601ffe9d4b73b7ac1eeeL42-L52) [[2]](diffhunk://#diff-b102daf76304a35b2fc0a53b39e3d2490f1f88373ed3c9dcbddb8f60c0a38baaL61-R78) [[3]](diffhunk://#diff-d03bb560ec65aea56e6a74f4e6f7ef32cd44a08d354190f26df645f5e95231dcL62-R70) [[4]](diffhunk://#diff-851d1eadda3f82d084b249979193f09471481b3c0c8624095131aa45ef6d5b94L65-R81)

**Project Metadata Updates:**

* Updated the `description` fields in the `pom` configuration for each module to accurately reflect their purpose (e.g., "Moss Core module", "Moss Paper module", etc.). [[1]](diffhunk://#diff-72cbe082f9ddb320919fd00247b5b1ee9d694751fca9601ffe9d4b73b7ac1eeeL65-R56) [[2]](diffhunk://#diff-b102daf76304a35b2fc0a53b39e3d2490f1f88373ed3c9dcbddb8f60c0a38baaL61-R78) [[3]](diffhunk://#diff-851d1eadda3f82d084b249979193f09471481b3c0c8624095131aa45ef6d5b94L65-R81)

**CI/CD Workflow Improvements:**

* Modified the GitHub Actions deployment workflow to explicitly publish all modules (`:moss`, `:moss-paper`, `:moss-velocity`, `:moss-bungeecord`) for both release and snapshot branches, instead of using the generic `publish` task.