### PR TITLE
Use in-memory PGP keys for Gradle signing

### DIFF
--- a/moss-bungeecord/build.gradle
+++ b/moss-bungeecord/build.gradle
@@ -112,6 +112,8 @@ centralPortal {
 }
 
 signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
 }

--- a/moss-paper/build.gradle
+++ b/moss-paper/build.gradle
@@ -109,6 +109,8 @@ centralPortal {
 }
 
 signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
 }

--- a/moss-velocity/build.gradle
+++ b/moss-velocity/build.gradle
@@ -109,6 +109,8 @@ centralPortal {
 }
 
 signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
 }

--- a/moss/build.gradle
+++ b/moss/build.gradle
@@ -81,6 +81,8 @@ publishing {
 }
 
 signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
 }


### PR DESCRIPTION
Replace useGpgCmd() and explicit mavenJava signing with in-memory PGP key signing in Gradle build files. Updated moss, moss-bungeecord, moss-paper, and moss-velocity to read signingKey and signingPassword project properties, call useInMemoryPgpKeys(signingKey, signingPassword), and sign publishing.publications so CI can sign artifacts without an external GPG agent.